### PR TITLE
Fix: updating or deleting banners created outside the extension writes to a wrong settings key

### DIFF
--- a/src/models/global-message-banners.ts
+++ b/src/models/global-message-banners.ts
@@ -5,6 +5,7 @@
 
 const markdownLinkRegex = /\[([^\[\]]+)\]\(([^\(\)]+)\)/g;
 const aTagLinkRegex = /<a href=["']([^<>]+)["']>([^<>]+)<\/a>/g;
+const entryNameConventionRegex = /^(p[0-2])-(.+)$/;
 
 export enum Priority {
     p0, p1, p2,
@@ -21,6 +22,12 @@ export class GlobalMessageBanner {
     public message: string;
     public expirationDate: Date;
 
+    // The raw settings entry name this banner was loaded from. Banners created outside this
+    // extension (e.g. the az devops CLI or the REST API) do not follow the extension's
+    // "p{priority}-{messageId}" naming convention, so the original entry name must be
+    // preserved to update or delete the same entry instead of writing to a new one.
+    public entryName: string;
+
     public constructor() {
         this.priority = Priority.p2;
         this.level = Level.Info;
@@ -35,7 +42,7 @@ export class GlobalMessageBanner {
     }
 
     public static fromWebEntity(entity: ObjectListWithCount<WebGlobalMessageBanner>): GlobalMessageBanner[] {
-        if (entity == null && entity.value == null) {
+        if (entity == null || entity.value == null) {
             return null;
         }
 
@@ -43,8 +50,14 @@ export class GlobalMessageBanner {
         Object.keys(entity.value).forEach((title) => {
             const banner = new GlobalMessageBanner();
             const body = entity.value[title];
-            banner.priority = Priority[title.slice(0, 2)];
-            banner.messageId = title.slice(3);
+            banner.entryName = title;
+            const conventionMatch = entryNameConventionRegex.exec(title);
+            if (conventionMatch != null) {
+                banner.priority = Priority[conventionMatch[1]];
+                banner.messageId = conventionMatch[2];
+            } else {
+                banner.messageId = title;
+            }
             banner.message = body.message.replace(aTagLinkRegex, `[$2]($1)`);
             banner.level = Level[this.fixTypeCase(body.level)];
             banner.expirationDate = body.expirationDate != null ? new Date(body.expirationDate) : null;
@@ -55,7 +68,9 @@ export class GlobalMessageBanner {
 
     public toWebEntity(): {[name: string]: WebGlobalMessageBanner} {
         const ret: {[name: string]: WebGlobalMessageBanner} = {};
-        const title = `GlobalMessageBanners/${Priority[this.priority]}-${this.messageId}`;
+        const entryName = this.entryName != null
+            ? this.entryName : `${Priority[this.priority]}-${this.messageId}`;
+        const title = `GlobalMessageBanners/${entryName}`;
 
         ret[title] = {
             level: Level[this.level],


### PR DESCRIPTION
Banners created via the az devops CLI or the Settings REST API have arbitrary entry names that do not follow the extension's "p{priority}-{messageId}" naming convention. fromWebEntity() parsed those names with fixed slice offsets, producing priority "undefined" and a truncated id. On save, toWebEntity() rebuilt the settings key from those corrupted parts, so the PATCH wrote a new "GlobalMessageBanners/undefined-..." entry instead of updating the original, and delete removed a nonexistent key. Edits appeared to succeed but never persisted.

Preserve the raw settings entry name on each loaded banner and write back to exactly that key. The "p{priority}-{messageId}" convention is still generated for new banners and parsed when it applies, so banners created by the extension are unaffected.

Also fix the null guard in fromWebEntity(), which used && instead of || and would throw on a null response instead of returning null.